### PR TITLE
use timing-attack safe HMAC comparison

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -18,8 +18,11 @@ const requestHandler = (request, response) => {
 
         var calculated = crypto.createHmac('sha256', process.env.CRONOFY_CLIENT_SECRET).update(body).digest('base64');
         console.log('Calculated HMAC: ' + calculated);
+        
+        var sentBuffer = new Buffer(sent, 'base64');
+        var calculatedBuffer = new Buffer(calculated, 'base64');
 
-        match = calculated === sent;
+        match = (sentBuffer.length === calculatedBuffer.length) && crypto.timingSafeEqual(sentBuffer, calculatedBuffer);
         console.log('Match: ' + match);
 
         response.end(match.toString());


### PR DESCRIPTION
This uses [Node 6.6's built-in method](https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b). Though scmp or something else from npm could also be used, I didn't want to introduce any dependencies.